### PR TITLE
Add Korean TokTok to Websites section

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A curated list of resources for learning Korean.
 * [KPedia](https://www.kpedia.jp/)
 * [Naver online dictionary](https://korean.dict.naver.com/english) 
 * [EBS Durian 표준한국어](https://www.ebs.co.kr/durian/kr/course?language=standardKorean)
+* [Korean TokTok](https://koreantoktok.com) -- free 4-stage curriculum (Hangul → TOPIK 6) with multilingual UI (en/id/vi/de) and free interactive tools (Korean keyboard, Hangul romanizer, TOPIK score calculator, Sino/Native number converter); no signup
 
 ## Radio
 


### PR DESCRIPTION
Hi — thanks for maintaining this list, it's been one of the more curated awesome-korean lists I've found.

I'd like to suggest adding **Korean TokTok** (https://koreantoktok.com) to the **Websites** section.

## What it is

A free 4-stage Korean curriculum (Hangul → TOPIK 6) running as an open web platform — no signup, no paywall.

## Why it fits the Websites section

The current Websites entries are mostly dictionaries (KPedia, Naver) and one course platform (EBS Durian). Korean TokTok complements them by adding:

- A structured curriculum with progression (Stage 1 Hangul/basics → Stage 4 advanced/TOPIK)
- Four free interactive tools: Korean keyboard, Hangul romanizer, TOPIK score calculator, Sino/Native number converter
- Multilingual UI: English, Bahasa Indonesia, Tiếng Việt, Deutsch (most KSL resources are EN-only or KR-only)
- Editorial AI-content disclosure on /editors with a structured corrections process

## Related (in case it's useful)

- Hangul roadmap post (with linked tools): https://koreantoktok.substack.com/p/learn-hangul-in-1-hour-the-practical
- Realistic 4-stage learning timeline: https://koreantoktok.substack.com/p/how-long-does-it-take-to-learn-korean

Happy to revise the description/wording or move it to a different section if you'd prefer. No hard feelings if it doesn't fit your editorial scope.