### PR TITLE
Add Pokelingo to Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A curated list of resources for learning Korean.
 * [Naver online dictionary](https://korean.dict.naver.com/english) 
 * [EBS Durian 표준한국어](https://www.ebs.co.kr/durian/kr/course?language=standardKorean)
 * [Tubelang](https://tubelang.com)
+* [Pokelingo](https://pokelingo.io/en/riddle/?lang=ko)
 
 ## Radio
 


### PR DESCRIPTION
Adds Pokelingo to Websites.

Browser-based daily reading puzzle: read a Pokédex entry in Korean and guess which of the 1,025 Pokémon it describes within five tries. Free, no signup. Practices reading and Pokémon vocabulary in Korean.

Disclosure: I built it.